### PR TITLE
fix: accept URL and DSN as connection string

### DIFF
--- a/migration_runners.go
+++ b/migration_runners.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 )
 
@@ -87,16 +86,4 @@ func (r *FileMigrationRunner) executeFile(ctx context.Context, conn DatabaseConn
 
 	_, err = conn.ExecContext(ctx, string(content))
 	return err
-}
-
-// AlphabeticalMigrationFilesSorting makes a copy of the provided slice
-// and sorts migration files alphabetically in the copied slice.
-//
-// The original slice is not modified.
-func AlphabeticalMigrationFilesSorting(files []string) []string {
-	sorted := make([]string, len(files))
-	copy(sorted, files)
-
-	sort.Strings(sorted)
-	return sorted
 }

--- a/migration_runners_ordering_funcs.go
+++ b/migration_runners_ordering_funcs.go
@@ -1,0 +1,15 @@
+package pgdbtemplate
+
+import "sort"
+
+// AlphabeticalMigrationFilesSorting makes a copy of the provided slice
+// and sorts migration files alphabetically in the copied slice.
+//
+// The original slice is not modified.
+func AlphabeticalMigrationFilesSorting(files []string) []string {
+	sorted := make([]string, len(files))
+	copy(sorted, files)
+
+	sort.Strings(sorted)
+	return sorted
+}


### PR DESCRIPTION
- Fix `isPostgresConnectionString` to accept both URL and DSN formats, as promised in `ReplaceDatabaseInConnectionString`. Empty connection strings are prohibited for defensive programming;
- Putting migration runners' ordering functions into a separate file to simplify reading;
- Minor godoc and code-style changes.